### PR TITLE
[Aikido] Add head field

### DIFF
--- a/Formula/aikido0.rb
+++ b/Formula/aikido0.rb
@@ -3,6 +3,7 @@ class Aikido0 < Formula
   homepage "https://github.com/personalrobotics/aikido/"
   url "https://github.com/personalrobotics/aikido/archive/v0.0.1.tar.gz"
   sha256 "1693978ed7b72686fefbe396e993826946dc40c03e6a2f11dbe1c5829a69c3d1"
+  head "https://github.com/personalrobotics/aikido.git"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
so that we can install the most recent Aikido as
```shell
brew install aikido0 --HEAD
```